### PR TITLE
Preferences and extended horizontal line

### DIFF
--- a/Editor/HierarchyTreeSettings.cs
+++ b/Editor/HierarchyTreeSettings.cs
@@ -1,0 +1,63 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace DyrdaDev.ForUnity.Hierarchy
+{
+    [FilePath("Hierarchy/HierarchyTree/Settings.asset", FilePathAttribute.Location.PreferencesFolder)]
+    internal class HierarchyTreeSettings : ScriptableSingleton<HierarchyTreeSettings> {
+        [field: SerializeField]
+        public bool Enabled {get; private set;} = true;
+
+        [field: SerializeField]
+        public float EdgeWidth {get; private set;} = 1.0f;
+        [field: SerializeField]
+        public Color EdgeColor {get; private set;} =  new Color(0.46f, 0.46f, 0.46f);
+        [field: SerializeField]
+        public Color HighlightedEdgeColor {get; private set;} = new Color(0.49f, 0.678f, 0.952f);
+
+        [SettingsProvider]
+        public static SettingsProvider CreateHierarchyTreeSettingsProvider() {
+            var keywords = new string[]{"Hierarchy", "Tree", "Edge Width", "Edge Color", "Highlighted Edge Color"};
+
+            return new SettingsProvider("Preferences/Hierarchy/Hierarchy Tree", SettingsScope.User, keywords) {
+                guiHandler = (searchContext) => {
+                    instance.SetEnabled(EditorGUILayout.Toggle("Active", instance.Enabled));
+                    instance.SetEdgeWidth(EditorGUILayout.Slider("Edge Width", instance.EdgeWidth, 1f, 6f));
+                    instance.SetEdgeColor(EditorGUILayout.ColorField("Edge Color", instance.EdgeColor));
+                    instance.SetHighlightEdgeColor(EditorGUILayout.ColorField(
+                        "Highlighted Edge Color", instance.HighlightedEdgeColor));
+                }
+            };
+        }
+        
+        private void SaveWhenDifferent<T>(T oldValue, T newValue) {
+            if (!oldValue.Equals(newValue))
+                Save(true);
+        }
+
+        private void SetEnabled(bool enabled) {
+            var old = Enabled;
+            Enabled = enabled;
+            SaveWhenDifferent(old, Enabled);
+        }
+
+        private void SetEdgeWidth(float edgeWidth) {
+            var old = EdgeWidth;
+            EdgeWidth = edgeWidth;
+            SaveWhenDifferent(old, EdgeWidth);
+        }
+
+        private void SetEdgeColor(Color edgeColor) {
+            var old = EdgeColor;
+            EdgeColor = edgeColor;
+            SaveWhenDifferent(old, EdgeColor);
+        }
+
+        private void SetHighlightEdgeColor(Color highlightedEdgeColor) {
+            var old = HighlightedEdgeColor;
+            HighlightedEdgeColor = highlightedEdgeColor;
+            SaveWhenDifferent(old, HighlightedEdgeColor);
+        }
+    }
+}

--- a/Editor/HierarchyTreeSettings.cs
+++ b/Editor/HierarchyTreeSettings.cs
@@ -5,7 +5,8 @@ using UnityEngine;
 namespace DyrdaDev.ForUnity.Hierarchy
 {
     [FilePath("Hierarchy/HierarchyTree/Settings.asset", FilePathAttribute.Location.PreferencesFolder)]
-    internal class HierarchyTreeSettings : ScriptableSingleton<HierarchyTreeSettings> {
+    internal class HierarchyTreeSettings : ScriptableSingleton<HierarchyTreeSettings>
+    {
         [field: SerializeField]
         public bool Enabled {get; private set;} = true;
 
@@ -17,10 +18,12 @@ namespace DyrdaDev.ForUnity.Hierarchy
         public Color HighlightedEdgeColor {get; private set;} = new Color(0.49f, 0.678f, 0.952f);
 
         [SettingsProvider]
-        public static SettingsProvider CreateHierarchyTreeSettingsProvider() {
+        public static SettingsProvider CreateHierarchyTreeSettingsProvider()
+        {
             var keywords = new string[]{"Hierarchy", "Tree", "Edge Width", "Edge Color", "Highlighted Edge Color"};
 
-            return new SettingsProvider("Preferences/Hierarchy/Hierarchy Tree", SettingsScope.User, keywords) {
+            return new SettingsProvider("Preferences/Hierarchy/Hierarchy Tree", SettingsScope.User, keywords)
+            {
                 guiHandler = (searchContext) => {
                     instance.SetEnabled(EditorGUILayout.Toggle("Active", instance.Enabled));
                     instance.SetEdgeWidth(EditorGUILayout.Slider("Edge Width", instance.EdgeWidth, 1f, 6f));
@@ -31,30 +34,37 @@ namespace DyrdaDev.ForUnity.Hierarchy
             };
         }
         
-        private void SaveWhenDifferent<T>(T oldValue, T newValue) {
+        private void SaveWhenDifferent<T>(T oldValue, T newValue)
+        {
             if (!oldValue.Equals(newValue))
+            {
                 Save(true);
+            }
         }
 
-        private void SetEnabled(bool enabled) {
+        private void SetEnabled(bool enabled)
+        {
             var old = Enabled;
             Enabled = enabled;
             SaveWhenDifferent(old, Enabled);
         }
 
-        private void SetEdgeWidth(float edgeWidth) {
+        private void SetEdgeWidth(float edgeWidth)
+        {
             var old = EdgeWidth;
             EdgeWidth = edgeWidth;
             SaveWhenDifferent(old, EdgeWidth);
         }
 
-        private void SetEdgeColor(Color edgeColor) {
+        private void SetEdgeColor(Color edgeColor)
+        {
             var old = EdgeColor;
             EdgeColor = edgeColor;
             SaveWhenDifferent(old, EdgeColor);
         }
 
-        private void SetHighlightEdgeColor(Color highlightedEdgeColor) {
+        private void SetHighlightEdgeColor(Color highlightedEdgeColor)
+        {
             var old = HighlightedEdgeColor;
             HighlightedEdgeColor = highlightedEdgeColor;
             SaveWhenDifferent(old, HighlightedEdgeColor);

--- a/Editor/HierarchyTreeSettings.cs.meta
+++ b/Editor/HierarchyTreeSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: edc64f2ffc4a38d4e9053911f2a4293b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ I recommend **installing this package from a Git URL using the Package Manager w
 
 > You can find more information [here](https://docs.unity3d.com/Manual/upm-ui-giturl.html).
 
+## Customization
+The tree can be customized or disabled under `Edit > Preferences... > Hierarchy > Hierarchy Tree`.
+
 ## License
 
 This package is licensed under an MIT license. See the [LICENSE](/LICENSE.md) file for details. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev.dyrda.hierarchy-tree-for-unity",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "displayName": "Hierarchy Tree",
   "description": "Hierarchy Tree renders a tree view in the project hierarchy.",
   "unity": "2019.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev.dyrda.hierarchy-tree-for-unity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "displayName": "Hierarchy Tree",
   "description": "Hierarchy Tree renders a tree view in the project hierarchy.",
   "unity": "2019.1",


### PR DESCRIPTION
Hello,
I made some changes for myself and created this pull request in case you are interested in adding them.

# What I did:
- I have added a settings page in the preference window
- extended the horizontal line when a gameobject has no children

# Preferences
The main reason I created the settings panel is to give the user the ability to disable the package.
I really like this package but I have not used it much because I did not want to force these visual changes on to others working on the same project.
In the preferences every user now can decide for them self whether they want to see the tree hierarchy and how it should look.
![preferences](https://github.com/user-attachments/assets/45fcddad-6b9e-426c-9dff-17d0664d27d0)

# Extended line
In my opinion the the space between the horizontal line and gameobjects without children was a little large.
Therefore I extended the line when the gameobject has no children.
<div align="center">

Old | Changed
:-: | :-:
![old](https://github.com/user-attachments/assets/b4bf0541-ed3b-4f91-b5dc-778179ae2d7f) | ![new](https://github.com/user-attachments/assets/a8f3e240-66ea-4932-a17c-d871a9aa1b57)

</div>